### PR TITLE
Add and apply custom ViewSet classes

### DIFF
--- a/addon_service/authorized_storage_account/views.py
+++ b/addon_service/authorized_storage_account/views.py
@@ -3,7 +3,8 @@ from rest_framework_json_api.views import ModelViewSet
 from .models import AuthorizedStorageAccount
 from .serializers import AuthorizedStorageAccountSerializer
 
+from addon_service.common.viewsets import RetrieveWriteViewSet
 
-class AuthorizedStorageAccountViewSet(ModelViewSet):
+class AuthorizedStorageAccountViewSet(RetrieveWriteViewSet):
     queryset = AuthorizedStorageAccount.objects.all()
     serializer_class = AuthorizedStorageAccountSerializer

--- a/addon_service/common/viewsets.py
+++ b/addon_service/common/viewsets.py
@@ -1,0 +1,21 @@
+from rest_framework.viewsets import GenericViewSet
+from rest_framework import mixins as drf_mixins
+from rest_framework_json_api.views import AutoPrefetchMixin, PreloadIncludesMixin, RelatedMixin
+
+
+class _DrfJsonApiHelpers(AutoPrefetchMixin, PreloadIncludesMixin, RelatedMixin):
+    pass
+
+class RetrieveOnlyViewSet(_DrfJsonApiHelpers, drf_mixins.RetrieveModelMixin, GenericViewSet):
+    http_method_names = ["get", "head", "options"]
+
+
+class RetrieveWriteViewSet(
+    _DrfJsonApiHelpers,
+    drf_mixins.CreateModelMixin,
+    drf_mixins.RetrieveModelMixin,
+    drf_mixins.UpdateModelMixin,
+    drf_mixins.DestroyModelMixin,
+    GenericViewSet
+):
+    http_method_names = ["get", "post", "patch", "delete", "head", "options"]

--- a/addon_service/configured_storage_addon/views.py
+++ b/addon_service/configured_storage_addon/views.py
@@ -1,9 +1,8 @@
-from rest_framework_json_api.views import ModelViewSet
-
 from .models import ConfiguredStorageAddon
 from .serializers import ConfiguredStorageAddonSerializer
 
+from addon_service.common.viewsets import RetrieveWriteViewSet
 
-class ConfiguredStorageAddonViewSet(ModelViewSet):
+class ConfiguredStorageAddonViewSet(RetrieveWriteViewSet):
     queryset = ConfiguredStorageAddon.objects.all()
     serializer_class = ConfiguredStorageAddonSerializer

--- a/addon_service/external_storage_service/views.py
+++ b/addon_service/external_storage_service/views.py
@@ -1,10 +1,10 @@
-from rest_framework_json_api.views import ModelViewSet
+from rest_framework_json_api.views import ReadOnlyViewSet
 
 from .models import ExternalStorageService
 from .serializers import ExternalStorageServiceSerializer
 
 
-class ExternalStorageServiceViewSet(ModelViewSet):
+class ExternalStorageServiceViewSet(ReadOnlyViewSet):
     queryset = ExternalStorageService.objects.all()
     serializer_class = ExternalStorageServiceSerializer
     # TODO: permissions_classes

--- a/addon_service/resource_reference/views.py
+++ b/addon_service/resource_reference/views.py
@@ -1,10 +1,10 @@
-from rest_framework_json_api.views import ReadOnlyModelViewSet
-
 from .models import ResourceReference
 from .serializers import ResourceReferenceSerializer
 
+from addon_service.common.viewsets import RetrieveOnlyViewSet
 
-class ResourceReferenceViewSet(ReadOnlyModelViewSet):
+class ResourceReferenceViewSet(RetrieveOnlyViewSet):
     queryset = ResourceReference.objects.all()
     serializer_class = ResourceReferenceSerializer
     # TODO: permissions_classes
+

--- a/addon_service/user_reference/views.py
+++ b/addon_service/user_reference/views.py
@@ -1,10 +1,9 @@
-from rest_framework_json_api.views import ReadOnlyModelViewSet
-
 from .models import UserReference
 from .serializers import UserReferenceSerializer
 
+from addon_service.common.viewsets import RetrieveOnlyViewSet
 
-class UserReferenceViewSet(ReadOnlyModelViewSet):
+class UserReferenceViewSet(RetrieveOnlyViewSet):
     queryset = UserReference.objects.all()
     serializer_class = UserReferenceSerializer
     # TODO: permissions_classes


### PR DESCRIPTION
### What:
Adding custom ViewSet classes to better control the methods generated/exposed by the routers. The two new view set classes are:

RetrieveOnlyViewSet:
Supports GET requests to urls like `addons.osf.io/v1/{resource-type}/{pk}`

RetrieveWriteViewSet:
Supports GET/PATCH/DELETE requests to urls like `addons.osf.io/v1/{resource-type}/{pk}`
Supports POST requests to urls like `addons.osf.io/v1/{resource-type}/`

Notably, neither class supports GET requests to urls like `addons.osf.io/v1/{resource-type}/`

### Why:
Of our top-level entities, only ExternalStorageService supports a List View (all of our other supported List Views are relationship views). Meanwhile, existing, out-of-the-box ViewSets from DRF and DRF-JSON API all provide both `retrieve` AND `list` functionality.

### How:
* Create custom ViewSets mimicking the DRF-JSON API definitions [here](https://github.com/django-json-api/django-rest-framework-json-api/blob/main/rest_framework_json_api/views.py#L216) using only the appropriate mixins from DRF.
* Update the base classes for our ViewSets to inherit the correct new ViewSets.

### Future Steps
* Determine the best path for allowing the OSF to disable users (either by adapting a new ViewSet that allows GET+PATCH behavior, a custom action on the UserReferenceModelViewSet, or via shared task queue)
*  Implement selection of appropriate permission by action as per the [DRF Docs](https://www.django-rest-framework.org/api-guide/viewsets/#introspecting-viewset-actions)