### PR TITLE
[ENG-5460] converge with frontend

### DIFF
--- a/addon_service/addon_operation_invocation/models.py
+++ b/addon_service/addon_operation_invocation/models.py
@@ -90,7 +90,7 @@ class AddonOperationInvocation(AddonsServiceBaseModel):
         return self.thru_account.storage_imp_config()
 
     def set_exception(self, exception: BaseException) -> None:
-        self.invocation_status = InvocationStatus.EXCEPTION
+        self.invocation_status = InvocationStatus.ERROR
         self.exception_type = type(exception).__qualname__
         self.exception_message = repr(exception)
         _tb = traceback.TracebackException.from_exception(exception)

--- a/addon_service/addon_operation_invocation/serializers.py
+++ b/addon_service/addon_operation_invocation/serializers.py
@@ -1,15 +1,9 @@
-from rest_framework.exceptions import (
-    PermissionDenied,
-    ValidationError,
-)
+from rest_framework.exceptions import ValidationError
 from rest_framework_json_api import serializers
 from rest_framework_json_api.relations import ResourceRelatedField
 from rest_framework_json_api.utils import get_resource_type_from_model
 
-from addon_service.common import (
-    osf,
-    view_names,
-)
+from addon_service.common import view_names
 from addon_service.common.enum_serializers import EnumNameChoiceField
 from addon_service.common.invocation_status import InvocationStatus
 from addon_service.common.serializer_fields import DataclassRelatedDataField
@@ -20,12 +14,6 @@ from addon_service.models import (
     ConfiguredStorageAddon,
     UserReference,
 )
-from addon_toolkit import (
-    AddonOperationDeclaration,
-    AddonOperationType,
-)
-
-from .perform import perform_invocation__blocking
 
 
 RESOURCE_TYPE = get_resource_type_from_model(AddonOperationInvocation)
@@ -103,48 +91,11 @@ class AddonOperationInvocationSerializer(serializers.HyperlinkedModelSerializer)
         _operation = _imp_cls.get_operation_declaration(_operation_name)
         _request = self.context["request"]
         _user_uri = _request.session.get("user_reference_uri")
-        if not self._has_create_permission(
-            _request, _user_uri, _operation, _thru_account, _thru_addon
-        ):
-            raise PermissionDenied
-        ###
-        # ok now do the creation
         _user, _ = UserReference.objects.get_or_create(user_uri=_user_uri)
-        _invocation = AddonOperationInvocation.objects.create(
+        return AddonOperationInvocation(
             operation=AddonOperationModel(_imp_cls, _operation),
             operation_kwargs=validated_data["operation_kwargs"],
             thru_addon=_thru_addon,
             thru_account=_thru_account,
             by_user=_user,
-        )
-        match _operation.operation_type:
-            case AddonOperationType.REDIRECT | AddonOperationType.IMMEDIATE:
-                perform_invocation__blocking(_invocation)
-            case AddonOperationType.EVENTUAL:
-                raise NotImplementedError("TODO: enqueue task")
-            case _:
-                raise ValueError(f"unknown operation type: {_operation.operation_type}")
-        return _invocation
-
-    def _has_create_permission(
-        self,
-        request,
-        user_uri: str,
-        operation: AddonOperationDeclaration,
-        thru_account: AuthorizedStorageAccount,
-        thru_addon: ConfiguredStorageAddon | None,
-    ) -> bool:
-        if thru_addon is None:
-            # when invoking thru account, must be the owner
-            return user_uri == thru_account.owner_uri
-        # when invoking thru addon, may be either...
-        return bool(
-            # the addon owner:
-            (user_uri == thru_addon.owner_uri)
-            # or a user with "read" access on the connected osf project:
-            or osf.has_osf_permission_on_resource(
-                request,
-                thru_addon.authorized_resource.resource_uri,
-                osf.OSFPermission.for_capabilities(operation.capability),
-            )
         )

--- a/addon_service/addon_operation_invocation/views.py
+++ b/addon_service/addon_operation_invocation/views.py
@@ -2,10 +2,13 @@ from addon_service.common.permissions import (
     IsAuthenticated,
     SessionUserIsOwner,
     SessionUserMayAccessInvocation,
+    SessionUserMayPerformInvocation,
 )
 from addon_service.common.viewsets import RetrieveWriteViewSet
+from addon_toolkit import AddonOperationType
 
 from .models import AddonOperationInvocation
+from .perform import perform_invocation__blocking
 from .serializers import AddonOperationInvocationSerializer
 
 
@@ -20,10 +23,23 @@ class AddonOperationInvocationViewSet(RetrieveWriteViewSet):
             case "partial_update" | "update" | "destroy":
                 return [IsAuthenticated(), SessionUserIsOwner()]
             case "create":
-                return [IsAuthenticated()]  # additional checks in serializer
+                return [IsAuthenticated(), SessionUserMayPerformInvocation()]
             case None:
                 return super().get_permissions()
             case _:
                 raise NotImplementedError(
                     f"no permission implemented for action '{self.action}'"
                 )
+
+    def perform_create(self, serializer):
+        super().perform_create(serializer)
+        # after creating the AddonOperationInvocation, look into invoking it
+        _invocation = serializer.instance
+        _operation_type = _invocation.operation.operation_type
+        match _operation_type:
+            case AddonOperationType.REDIRECT | AddonOperationType.IMMEDIATE:
+                perform_invocation__blocking(_invocation)
+            case AddonOperationType.EVENTUAL:
+                raise NotImplementedError("TODO: enqueue task")
+            case _:
+                raise ValueError(f"unknown operation type: {_operation_type}")

--- a/addon_service/admin/__init__.py
+++ b/addon_service/admin/__init__.py
@@ -11,7 +11,7 @@ from .decorators import linked_many_field
 
 @admin.register(models.ExternalStorageService)
 class ExternalStorageServiceAdmin(GravyvaletModelAdmin):
-    list_display = ("name", "created", "modified")
+    list_display = ("display_name", "created", "modified")
     readonly_fields = (
         "id",
         "created",

--- a/addon_service/authorized_storage_account/models.py
+++ b/addon_service/authorized_storage_account/models.py
@@ -42,7 +42,7 @@ class AuthorizedStorageAccount(AddonsServiceBaseModel):
 
     objects = AuthorizedStorageAccountManager()
 
-    account_name = models.CharField(null=False, blank=True, default="")
+    _display_name = models.CharField(null=False, blank=True, default="")
     external_account_id = models.CharField(null=False, blank=True, default="")
     int_authorized_capabilities = models.IntegerField(
         validators=[validate_addon_capability]
@@ -83,6 +83,14 @@ class AuthorizedStorageAccount(AddonsServiceBaseModel):
 
     class JSONAPIMeta:
         resource_name = "authorized-storage-accounts"
+
+    @property
+    def display_name(self):
+        return self._display_name or self.external_service.display_name
+
+    @display_name.setter
+    def display_name(self, value: str):
+        self._display_name = value
 
     @property
     def external_service(self):
@@ -207,13 +215,13 @@ class AuthorizedStorageAccount(AddonsServiceBaseModel):
         if self._api_base_url and not service.configurable_api_root:
             raise ValidationError(
                 {
-                    "api_base_url": f"Cannot specify an api_base_url for Public-only service {service.name}"
+                    "api_base_url": f"Cannot specify an api_base_url for Public-only service {service.display_name}"
                 }
             )
         if ServiceTypes.PUBLIC not in service.service_type and not self.api_base_url:
             raise ValidationError(
                 {
-                    "api_base_url": f"Must specify an api_base_url for Hosted-only service {service.name}"
+                    "api_base_url": f"Must specify an api_base_url for Hosted-only service {service.display_name}"
                 }
             )
 

--- a/addon_service/authorized_storage_account/serializers.py
+++ b/addon_service/authorized_storage_account/serializers.py
@@ -108,6 +108,7 @@ class AuthorizedStorageAccountSerializer(serializers.HyperlinkedModelSerializer)
         fields = [
             "id",
             "url",
+            "display_name",
             "account_owner",
             "api_base_url",
             "auth_url",

--- a/addon_service/authorized_storage_account/serializers.py
+++ b/addon_service/authorized_storage_account/serializers.py
@@ -82,6 +82,7 @@ class AuthorizedStorageAccountSerializer(serializers.HyperlinkedModelSerializer)
         external_service = validated_data["external_storage_service"]
         try:
             authorized_account = AuthorizedStorageAccount.objects.create(
+                _display_name=validated_data.get("display_name", ""),
                 external_storage_service=external_service,
                 account_owner=account_owner,
                 authorized_capabilities=validated_data.get("authorized_capabilities"),

--- a/addon_service/common/invocation_status.py
+++ b/addon_service/common/invocation_status.py
@@ -5,4 +5,4 @@ class InvocationStatus(enum.Enum):
     STARTING = 1
     GOING = 2
     SUCCESS = 3
-    EXCEPTION = 128
+    ERROR = 128

--- a/addon_service/common/viewsets.py
+++ b/addon_service/common/viewsets.py
@@ -66,9 +66,20 @@ class RestrictedReadOnlyViewSet(ReadOnlyModelViewSet):
         return Response(serializer.data)
 
 
+class _CreateWithPermissionsMixin(drf_mixins.CreateModelMixin):
+    def perform_create(self, serializer):
+        super().perform_create(serializer)
+        _instance = serializer.instance
+        # check permissions on the created instance (which may or may not be saved)
+        self.check_object_permissions(self.request, _instance)
+        if serializer.instance._state.adding:
+            # the serializer didn't save it
+            _instance.save()
+
+
 class RetrieveWriteViewSet(
     _DrfJsonApiHelpers,
-    drf_mixins.CreateModelMixin,
+    _CreateWithPermissionsMixin,
     drf_mixins.RetrieveModelMixin,
     drf_mixins.UpdateModelMixin,
     GenericViewSet,
@@ -78,7 +89,7 @@ class RetrieveWriteViewSet(
 
 class RetrieveWriteDeleteViewSet(
     _DrfJsonApiHelpers,
-    drf_mixins.CreateModelMixin,
+    _CreateWithPermissionsMixin,
     drf_mixins.RetrieveModelMixin,
     drf_mixins.UpdateModelMixin,
     drf_mixins.DestroyModelMixin,

--- a/addon_service/common/viewsets.py
+++ b/addon_service/common/viewsets.py
@@ -2,10 +2,7 @@ import dataclasses
 import typing
 
 from rest_framework import mixins as drf_mixins
-from rest_framework.exceptions import (
-    NotFound,
-    PermissionDenied,
-)
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 from rest_framework.viewsets import (
     GenericViewSet,
@@ -56,7 +53,7 @@ class RestrictedReadOnlyViewSet(ReadOnlyModelViewSet):
         try:
             self.check_object_permissions(self.request, qs.get())
         except qs.model.DoesNotExist:
-            raise NotFound("Provided filter returned no results.")
+            return Response([])
         except qs.model.MultipleObjectsReturned:
             raise PermissionDenied(
                 "Filters to this endpoint must be uniquely identifying"

--- a/addon_service/configured_storage_addon/models.py
+++ b/addon_service/configured_storage_addon/models.py
@@ -26,8 +26,8 @@ class ConnectedStorageAddonManager(models.Manager):
 class ConfiguredStorageAddon(AddonsServiceBaseModel):
     objects = ConnectedStorageAddonManager()
 
+    _display_name = models.CharField(null=False, blank=True, default="")
     root_folder = models.CharField(blank=True)
-
     int_connected_capabilities = models.IntegerField(
         validators=[validate_addon_capability]
     )
@@ -50,6 +50,14 @@ class ConfiguredStorageAddon(AddonsServiceBaseModel):
 
     class JSONAPIMeta:
         resource_name = "configured-storage-addons"
+
+    @property
+    def display_name(self):
+        return self._display_name or self.base_account.display_name
+
+    @display_name.setter
+    def display_name(self, value: str):
+        self._display_name = value
 
     @property
     def connected_capabilities(self) -> AddonCapabilities:

--- a/addon_service/configured_storage_addon/serializers.py
+++ b/addon_service/configured_storage_addon/serializers.py
@@ -17,7 +17,7 @@ RESOURCE_TYPE = get_resource_type_from_model(ConfiguredStorageAddon)
 
 
 class ConfiguredStorageAddonSerializer(serializers.HyperlinkedModelSerializer):
-    root_folder = serializers.CharField(required=False)
+    root_folder = serializers.CharField(required=False, allow_blank=True)
     url = serializers.HyperlinkedIdentityField(
         view_name=view_names.detail_view(RESOURCE_TYPE)
     )

--- a/addon_service/configured_storage_addon/serializers.py
+++ b/addon_service/configured_storage_addon/serializers.py
@@ -58,6 +58,7 @@ class ConfiguredStorageAddonSerializer(serializers.HyperlinkedModelSerializer):
         fields = [
             "id",
             "url",
+            "display_name",
             "root_folder",
             "base_account",
             "authorized_resource",

--- a/addon_service/configured_storage_addon/views.py
+++ b/addon_service/configured_storage_addon/views.py
@@ -9,7 +9,7 @@ from addon_service.common.permissions import (
     IsValidHMACSignedRequest,
     SessionUserCanViewReferencedResource,
     SessionUserIsOwner,
-    SessionUserIsReferencedResourceAdmin,
+    SessionUserMayConnectAddon,
 )
 from addon_service.common.viewsets import RetrieveWriteDeleteViewSet
 from addon_service.common.waterbutler_compat import WaterButlerConfigurationSerializer
@@ -29,7 +29,7 @@ class ConfiguredStorageAddonViewSet(RetrieveWriteDeleteViewSet):
             case "partial_update" | "update" | "destroy":
                 return [IsAuthenticated(), SessionUserIsOwner()]
             case "create":
-                return [IsAuthenticated(), SessionUserIsReferencedResourceAdmin()]
+                return [IsAuthenticated(), SessionUserMayConnectAddon()]
             case "get_wb_config":
                 return [IsValidHMACSignedRequest()]
             case None:

--- a/addon_service/credentials/serializers.py
+++ b/addon_service/credentials/serializers.py
@@ -17,6 +17,8 @@ class CredentialsField(JSONField):
         super().__init__(write_only=write_only, required=required)
 
     def to_internal_value(self, data):
+        if not data:
+            return None  # consider empty {} same as omitting the field
         # No access to the credentials format here, so just try all of them
         for creds_format in SUPPORTED_CREDENTIALS_FORMATS:
             try:

--- a/addon_service/external_storage_service/models.py
+++ b/addon_service/external_storage_service/models.py
@@ -15,7 +15,7 @@ from addon_service.common.validators import (
 
 
 class ExternalStorageService(AddonsServiceBaseModel):
-    name = models.CharField(null=False)
+    display_name = models.CharField(null=False)
     int_addon_imp = models.IntegerField(
         null=False,
         validators=[validate_storage_imp_number],

--- a/addon_service/external_storage_service/models.py
+++ b/addon_service/external_storage_service/models.py
@@ -54,7 +54,7 @@ class ExternalStorageService(AddonsServiceBaseModel):
         resource_name = "external-storage-services"
 
     def __repr__(self):
-        return f'<{self.__class__.__qualname__}(pk="{self.pk}", name="{self.name}")>'
+        return f'<{self.__class__.__qualname__}(pk="{self.pk}", display_name="{self.display_name}")>'
 
     __str__ = __repr__
 

--- a/addon_service/external_storage_service/serializers.py
+++ b/addon_service/external_storage_service/serializers.py
@@ -37,6 +37,6 @@ class ExternalStorageServiceSerializer(serializers.HyperlinkedModelSerializer):
             "credentials_format",
             "max_concurrent_downloads",
             "max_upload_mb",
-            "name",
+            "display_name",
             "url",
         ]

--- a/addon_service/migrations/0001_initial.py
+++ b/addon_service/migrations/0001_initial.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
                 ),
                 ("created", models.DateTimeField(editable=False)),
                 ("modified", models.DateTimeField()),
-                ("account_name", models.CharField(blank=True, default="")),
+                ("_display_name", models.CharField(blank=True, default="")),
                 ("external_account_id", models.CharField(blank=True, default="")),
                 (
                     "int_authorized_capabilities",
@@ -188,7 +188,7 @@ class Migration(migrations.Migration):
                 ),
                 ("created", models.DateTimeField(editable=False)),
                 ("modified", models.DateTimeField()),
-                ("name", models.CharField()),
+                ("display_name", models.CharField()),
                 (
                     "int_addon_imp",
                     models.IntegerField(
@@ -256,6 +256,7 @@ class Migration(migrations.Migration):
                 ),
                 ("created", models.DateTimeField(editable=False)),
                 ("modified", models.DateTimeField()),
+                ("_display_name", models.CharField(blank=True, default="")),
                 ("root_folder", models.CharField(blank=True)),
                 (
                     "int_connected_capabilities",

--- a/addon_service/tests/_factories.py
+++ b/addon_service/tests/_factories.py
@@ -58,7 +58,7 @@ class ExternalStorageServiceFactory(DjangoModelFactory):
     class Meta:
         model = db.ExternalStorageService
 
-    name = factory.Faker("word")
+    display_name = factory.Faker("word")
     max_concurrent_downloads = factory.Faker("pyint")
     max_upload_mb = factory.Faker("pyint")
     int_addon_imp = known_imps.get_imp_number(known_imps.get_imp_by_name("BLARG"))
@@ -91,7 +91,7 @@ class AuthorizedStorageAccountFactory(DjangoModelFactory):
     class Meta:
         model = db.AuthorizedStorageAccount
 
-    account_name = factory.Faker("word")
+    display_name = factory.Faker("word")
     default_root_folder = "/"
     authorized_capabilities = AddonCapabilities.ACCESS | AddonCapabilities.UPDATE
 

--- a/addon_service/tests/test_by_type/test_configured_storage_addon.py
+++ b/addon_service/tests/test_by_type/test_configured_storage_addon.py
@@ -174,11 +174,8 @@ class ConfiguredStorageAddonPOSTTests(BaseAPITest):
             format="vnd.api+json",
         )
         self.assertEqual(response.status_code, HTTPStatus.CREATED)
-        self.assertTrue(
-            ConfiguredStorageAddon.objects.filter(
-                authorized_resource__resource_uri=new_resource_uri
-            ).exists()
-        )
+        _created = ConfiguredStorageAddon.objects.get(pk=response.data["id"])
+        self.assertEqual(_created.resource_uri, new_resource_uri)
 
 
 class TestWBConfigRetrieval(APITestCase):

--- a/addon_service/tests/test_by_type/test_external_storage_service.py
+++ b/addon_service/tests/test_by_type/test_external_storage_service.py
@@ -126,7 +126,7 @@ class TestExternalStorageServiceViewSet(TestCase):
                     "max_concurrent_downloads",
                     "max_upload_mb",
                     "credentials_format",
-                    "name",
+                    "display_name",
                     "id",
                     "addon_imp",
                     "url",

--- a/addon_service/tests/test_by_type/test_user_reference.py
+++ b/addon_service/tests/test_by_type/test_user_reference.py
@@ -65,6 +65,7 @@ class TestUserReferenceAPI(APITestCase):
                 _content["data"]["relationships"].keys(),
                 {
                     "authorized_storage_accounts",
+                    "configured_resources",
                 },
             )
 
@@ -197,6 +198,7 @@ class TestUserReferenceViewSet(TestCase):
             set(_content["data"]["relationships"].keys()),
             {
                 "authorized_storage_accounts",
+                "configured_resources",
             },
         )
 

--- a/addon_service/urls.py
+++ b/addon_service/urls.py
@@ -31,7 +31,7 @@ class _AddonServiceRouter(SimpleRouter):
     ]
 
 
-_router = _AddonServiceRouter()
+_router = _AddonServiceRouter(trailing_slash=False)
 
 
 def _register_viewset(viewset):

--- a/addon_service/user_reference/models.py
+++ b/addon_service/user_reference/models.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from addon_service.authorized_storage_account.models import AuthorizedStorageAccount
 from addon_service.common.base_model import AddonsServiceBaseModel
 from addon_service.configured_storage_addon.models import ConfiguredStorageAddon
+from addon_service.resource_reference.models import ResourceReference
 
 
 class UserReference(AddonsServiceBaseModel):
@@ -14,6 +15,12 @@ class UserReference(AddonsServiceBaseModel):
     def configured_storage_addons(self):
         return ConfiguredStorageAddon.objects.filter(
             base_account__account_owner=self,
+        )
+
+    @property
+    def configured_resources(self):
+        return ResourceReference.objects.filter(
+            configured_storage_addons__base_account__account_owner=self,
         )
 
     class Meta:

--- a/addon_service/user_reference/models.py
+++ b/addon_service/user_reference/models.py
@@ -19,9 +19,14 @@ class UserReference(AddonsServiceBaseModel):
 
     @property
     def configured_resources(self):
-        return ResourceReference.objects.filter(
-            configured_storage_addons__base_account__account_owner=self,
-        )
+        return ResourceReference.objects.annotate(
+            has_addon_configured_by_user=models.Exists(
+                ConfiguredStorageAddon.objects.filter(
+                    authorized_resource_id=models.OuterRef("id"),
+                    base_account__account_owner=self,
+                )
+            )
+        ).filter(has_addon_configured_by_user=True)
 
     class Meta:
         verbose_name = "User Reference"

--- a/addon_service/user_reference/serializers.py
+++ b/addon_service/user_reference/serializers.py
@@ -5,6 +5,7 @@ from rest_framework_json_api.utils import get_resource_type_from_model
 from addon_service.common import view_names
 from addon_service.models import (
     AuthorizedStorageAccount,
+    ResourceReference,
     UserReference,
 )
 
@@ -23,9 +24,18 @@ class UserReferenceSerializer(serializers.HyperlinkedModelSerializer):
         related_link_view_name=view_names.related_view(RESOURCE_TYPE),
     )
 
+    configured_resources = HyperlinkedRelatedField(
+        many=True,
+        queryset=ResourceReference.objects.all(),
+        related_link_view_name=view_names.related_view(RESOURCE_TYPE),
+    )
+
     included_serializers = {
         "authorized_storage_accounts": (
             "addon_service.serializers.AuthorizedStorageAccountSerializer"
+        ),
+        "configured_resources": (
+            "addon_service.serializers.ResourceReferenceSerializer"
         ),
     }
 
@@ -36,4 +46,5 @@ class UserReferenceSerializer(serializers.HyperlinkedModelSerializer):
             "url",
             "user_uri",
             "authorized_storage_accounts",
+            "configured_resources",
         ]

--- a/app/authentication.py
+++ b/app/authentication.py
@@ -2,6 +2,7 @@ from rest_framework import authentication as drf_authentication
 from rest_framework.request import Request as DrfRequest
 
 from addon_service.common import osf
+from addon_service.models import UserReference
 
 
 class GVCombinedAuthentication(drf_authentication.BaseAuthentication):
@@ -10,8 +11,9 @@ class GVCombinedAuthentication(drf_authentication.BaseAuthentication):
     def authenticate(self, request: DrfRequest):
         _user_uri = osf.get_osf_user_uri(request._request)
         if _user_uri:
+            UserReference.objects.get_or_create(user_uri=_user_uri)
             request.session["user_reference_uri"] = _user_uri
-            return (True, None)  # TODO load UserReference?
+            return (True, None)
         return None  # unauthenticated
 
     def authenticate_header(self, request):

--- a/app/settings.py
+++ b/app/settings.py
@@ -122,7 +122,7 @@ if env.OSFDB_HOST:
 DATABASE_ROUTERS = ["addon_service.osf_models.db_router.OsfDatabaseRouter"]
 
 REST_FRAMEWORK = {
-    "PAGE_SIZE": 10,
+    "PAGE_SIZE": 101,
     "EXCEPTION_HANDLER": "addon_service.exception_handler.api_exception_handler",
     "DEFAULT_PAGINATION_CLASS": "rest_framework_json_api.pagination.JsonApiPageNumberPagination",
     "DEFAULT_PARSER_CLASSES": (


### PR DESCRIPTION
- add `display_name` field to external services, authorized accounts, and configured addons
    - required for external service
    - if blank for addon, fall back to account
    - if blank for account, fall back to external service
- set jsonapi type for `/configured-storage-accounts/{pk}/waterbutler-config/` (now has `"type": "waterbutler-config"`)
- ~admin interface (merged from #62 )~
- updates to [converge with frontend](https://github.com/CenterForOpenScience/ember-osf-web/pull/2234)
  - when `/v1/user-references?filter[user_uri]=...` or `/v2/resource-references?filter[resource_uri]=...` match no results, respond success with `"data": []` instead of 404 error
  - allow empty `"credentials": {}` on account creation, consider same as when omitted
  - allow blank `root_folder` for addons
  - stop adding trailing slashes
  - create `UserReference` to current user on successful auth

[ENG-5460]

[ENG-5460]: https://openscience.atlassian.net/browse/ENG-5460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ