### PR TITLE
[ENG-5725] support hmac-authenticated requests from osf

### DIFF
--- a/addon_service/authentication.py
+++ b/addon_service/authentication.py
@@ -9,7 +9,7 @@ class GVCombinedAuthentication(drf_authentication.BaseAuthentication):
     """Authentication supporting session, basic, and token methods."""
 
     def authenticate(self, request: DrfRequest):
-        _user_uri = osf.get_osf_user_uri(request._request)
+        _user_uri = osf.get_osf_user_uri(request)
         if _user_uri:
             UserReference.objects.get_or_create(user_uri=_user_uri)
             request.session["user_reference_uri"] = _user_uri

--- a/addon_service/common/hmac.py
+++ b/addon_service/common/hmac.py
@@ -1,62 +1,49 @@
 import base64
+import functools
 import hashlib
 import hmac
 import re
-import urllib
+import urllib.parse
 from datetime import (
     UTC,
     datetime,
+    timedelta,
 )
 
-from django.conf import settings
+from django.http import HttpRequest
 
 
+__all__ = (
+    "make_signed_headers",
+    "validate_signed_headers",
+    "TIMESTAMP_HEADER",
+)
+
+_AUTH_HEADER_PREFIX = "HMAC-"
 _AUTH_HEADER_REGEX = re.compile(
     r"^HMAC-SHA256 SignedHeaders=(?P<headers>[\w;-]*)&Signature=(?P<signature>[^\W_]*$)"
 )
+TIMESTAMP_HEADER = "X-Authorization-Timestamp"
+CONTENT_HASH_HEADER = "X-Content-SHA256"
 
 
-def _sign_message(message: str, hmac_key: str = None) -> str:
-    key = hmac_key or settings.DEFAULT_HMAC_KEY
-    encoded_message = base64.b64encode(message.encode())
-    return hmac.new(
-        key=key.encode(), digestmod=hashlib.sha256, msg=encoded_message
-    ).hexdigest()
-
-
-def _get_signed_components(
-    request_url: str, request_method: str, body: str | bytes
-) -> tuple[list[str], dict[str, str]]:
-    parsed_url = urllib.parse.urlparse(request_url)
-    if isinstance(body, str):
-        body = body.encode()
-    content_hash = hashlib.sha256(body).hexdigest if body else None
-    auth_timestamp = datetime.now(UTC)
-    signed_segments = [
-        request_method,
-        parsed_url.path,
-        parsed_url.query,
-        str(auth_timestamp),
-        content_hash,
-    ]
-    # Filter out query string and content_hash if none present
-    signed_segments = [segment for segment in signed_segments if segment]
-    signed_headers = {"X-Authorization-Timestamp": auth_timestamp}
-    if content_hash:
-        signed_headers["X-Content-SHA256"] = content_hash
-    return signed_segments, signed_headers
+###
+# public
 
 
 def make_signed_headers(
-    request_url: str, request_method: str, body: str | bytes = "", hmac_key: str = None
+    request_url: str,
+    request_method: str,
+    hmac_key: str,
+    request_content: bytes = b"",
+    additional_headers: dict[str, str] | None = None,
 ) -> dict:
     signed_string_segments, signed_headers = _get_signed_components(
-        request_url, request_method, body
+        request_url, request_method, request_content, additional_headers
     )
     signature = _sign_message(
         message="\n".join(signed_string_segments), hmac_key=hmac_key
     )
-
     signature_header_fields = ";".join(signed_headers.keys())
     auth_header_value = (
         f"HMAC-SHA256 SignedHeaders={signature_header_fields}&Signature={signature}"
@@ -67,26 +54,24 @@ def make_signed_headers(
     )
 
 
-def _reconstruct_string_to_sign_from_request(request, signed_headers: list[str]) -> str:
-    signed_segments = [request.method, request.path]
-    query_string = request.META.get("QUERY_STRING")
-    if query_string:
-        signed_segments.append(query_string)
-    signed_segments.extend(
-        [str(request.headers[signed_header]) for signed_header in signed_headers]
-    )
-    return "\n".join([segment for segment in signed_segments if segment])
-
-
-def validate_signed_headers(request, hmac_key=None):
-    match = _AUTH_HEADER_REGEX.match(request.headers.get("Authorization", ""))
+@functools.lru_cache
+def validate_signed_headers(
+    request: HttpRequest, hmac_key: str, expiration_seconds: int | None = None
+) -> dict[str, str]:
+    _authorization = request.headers.get("Authorization", "")
+    if not _authorization.startswith(_AUTH_HEADER_PREFIX):
+        raise NotUsingHmac
+    match = _AUTH_HEADER_REGEX.match(_authorization)
     if not match:
-        raise ValueError(
+        raise UnsupportedHmacAuthorization(
             "Message was not authorized via valid HMAC-SHA256 signed headers"
         )
     expected_signature = match.group("signature")
-    signed_headers = match.group("headers").split(";")
-
+    signed_header_names = match.group("headers").split(";")
+    signed_headers = {
+        _header_name: str(request.headers[_header_name])
+        for _header_name in signed_header_names
+    }
     computed_signature = _sign_message(
         message=_reconstruct_string_to_sign_from_request(
             request, signed_headers=signed_headers
@@ -94,10 +79,120 @@ def validate_signed_headers(request, hmac_key=None):
         hmac_key=hmac_key,
     )
     if not hmac.compare_digest(computed_signature, expected_signature):
-        raise ValueError("Could not verify HMAC signed request")
+        raise IncorrectHmacSignature("HMAC Signed Request has incorrect signature!")
+    if expiration_seconds is not None:
+        _validate_timestamp(signed_headers.get(TIMESTAMP_HEADER), expiration_seconds)
+    content_hash = signed_headers.get(CONTENT_HASH_HEADER)
+    if content_hash:
+        _validate_content_hash(content_hash, request.body)
+    return signed_headers
 
-    content_hash = request.headers.get("X-Content-SHA256")
-    if content_hash and not hmac.compare_digest(
-        content_hash, hashlib.sha256(request.body).hexdigest()
+
+def _validate_timestamp(signed_timestamp: str | None, expiration_seconds: int) -> None:
+    if not signed_timestamp:
+        raise UnsupportedHmacAuthorization(
+            f"HMAC Signed Request missing expected signed header '{TIMESTAMP_HEADER}'"
+        )
+    expiration_time = datetime.now(UTC) - timedelta(seconds=expiration_seconds)
+    request_time = datetime.fromisoformat(signed_timestamp)
+    if request_time < expiration_time:
+        raise ExpiredHmacTimestamp(
+            f"HMAC Signed Request is too old (expected at most {expiration_seconds} seconds)"
+        )
+    elif request_time > datetime.now(UTC):
+        raise FutureHmacTimestamp(
+            "HMAC Signed Request provided a timestamp from the future"
+        )
+
+
+def _validate_content_hash(sha256_hexdigest: str, request_content: bytes) -> None:
+    if sha256_hexdigest and not hmac.compare_digest(
+        sha256_hexdigest, hashlib.sha256(request_content).hexdigest()
     ):
-        raise ValueError("Computed content hash did not match value from headers")
+        raise IncorrectHmacContentHash(
+            "Computed content hash did not match value from headers"
+        )
+
+
+###
+# exceptions raised in this module
+
+
+class NotUsingHmac(ValueError):
+    pass
+
+
+class RejectedHmac(ValueError):
+    pass
+
+
+class ExpiredHmacTimestamp(RejectedHmac):
+    pass
+
+
+class FutureHmacTimestamp(RejectedHmac):
+    pass
+
+
+class UnsupportedHmacAuthorization(RejectedHmac):
+    pass
+
+
+class IncorrectHmacSignature(RejectedHmac):
+    pass
+
+
+class IncorrectHmacContentHash(RejectedHmac):
+    pass
+
+
+###
+# private helpers
+
+
+def _reconstruct_string_to_sign_from_request(
+    request: HttpRequest, signed_headers: dict[str, str]
+) -> str:
+    signed_segments = [request.method, request.path]
+    query_string = request.META.get("QUERY_STRING")
+    if query_string:
+        signed_segments.append(query_string)
+    signed_segments.extend(signed_headers.values())
+    return "\n".join(segment for segment in signed_segments if segment)
+
+
+def _sign_message(message: str, hmac_key: str) -> str:
+    encoded_message = base64.b64encode(message.encode())
+    return hmac.new(
+        key=hmac_key.encode(), digestmod=hashlib.sha256, msg=encoded_message
+    ).hexdigest()
+
+
+def _get_signed_components(
+    request_url: str,
+    request_method: str,
+    request_content: bytes,
+    additional_headers: dict[str, str] | None = None,
+) -> tuple[list[str], dict[str, str]]:
+    parsed_url = urllib.parse.urlparse(request_url)
+    content_hash = (
+        hashlib.sha256(request_content).hexdigest() if request_content else None
+    )
+    auth_timestamp = datetime.now(UTC).isoformat()
+    possible_signed_segments = [
+        request_method,
+        parsed_url.path,
+        parsed_url.query,
+        auth_timestamp,
+        content_hash,
+    ]
+    signed_headers = {TIMESTAMP_HEADER: auth_timestamp}
+    if content_hash:
+        signed_headers[CONTENT_HASH_HEADER] = content_hash
+    if additional_headers:
+        # order matters, so append additional headers at the end for consistency
+        possible_signed_segments.extend(additional_headers.values())
+        signed_headers.update(additional_headers)
+    # Filter out query string and content_hash if none present
+    signed_segments = [segment for segment in possible_signed_segments if segment]
+    return signed_segments, signed_headers

--- a/addon_service/common/permissions.py
+++ b/addon_service/common/permissions.py
@@ -88,7 +88,7 @@ class SessionUserMayPerformInvocation(permissions.BasePermission):
 class IsValidHMACSignedRequest(permissions.BasePermission):
     def has_permission(self, request, view):
         try:
-            hmac_utils.validate_signed_headers(
+            hmac_utils.validate_signed_request(
                 request,
                 settings.OSF_HMAC_KEY,
                 settings.OSF_HMAC_EXPIRATION_SECONDS,

--- a/addon_service/tests/_helpers.py
+++ b/addon_service/tests/_helpers.py
@@ -14,7 +14,6 @@ from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.contrib.sessions.backends.db import SessionStore
 from django.urls import reverse
-from rest_framework import exceptions as drf_exceptions
 from rest_framework.test import APIRequestFactory
 from rest_framework_json_api.utils import get_resource_type_from_model
 
@@ -47,7 +46,7 @@ class MockOSF:
     @contextlib.contextmanager
     def mocking(self):
         with patch(
-            "app.authentication.GVCombinedAuthentication.authenticate",
+            "addon_service.authentication.GVCombinedAuthentication.authenticate",
             side_effect=self._mock_user_check,
         ), patch(
             "addon_service.common.osf.has_osf_permission_on_resource",
@@ -98,9 +97,7 @@ class MockOSF:
     def _mock_resource_check(self, request, uri, required_permission, *args, **kwargs):
         caller = self._get_assumed_caller(cookies=request.COOKIES)
         permissions = self._get_user_permissions(user_uri=caller, resource_uri=uri)
-        if required_permission.lower() not in permissions:
-            raise drf_exceptions.PermissionDenied
-        return True
+        return bool(required_permission.lower() in permissions)
 
 
 class MockExternalService:

--- a/addon_service/tests/test_by_type/test_configured_storage_addon.py
+++ b/addon_service/tests/test_by_type/test_configured_storage_addon.py
@@ -201,6 +201,7 @@ class TestWBConfigRetrieval(APITestCase):
             headers=hmac_utils.make_signed_headers(
                 request_url=request_url,
                 request_method="GET",
+                hmac_key=settings.OSF_HMAC_KEY,
             ),
         )
         self.assertEqual(response.status_code, HTTPStatus.OK)
@@ -263,6 +264,7 @@ class TestWBConfigRetrieval(APITestCase):
             headers = hmac_utils.make_signed_headers(
                 request_url=request_url,
                 request_method="GET",
+                hmac_key=settings.OSF_HMAC_KEY,
             )
         response = self.client.get(request_url, headers=headers)
         self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
@@ -280,6 +282,7 @@ class TestWBConfigRetrieval(APITestCase):
             headers = hmac_utils.make_signed_headers(
                 request_url=request_url,
                 request_method="GET",
+                hmac_key=settings.OSF_HMAC_KEY,
             )
         response = self.client.get(request_url, headers=headers)
         self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)

--- a/addon_service/tests/test_by_type/test_resource_reference.py
+++ b/addon_service/tests/test_by_type/test_resource_reference.py
@@ -167,7 +167,7 @@ class TestResourceReferenceViewSet(TestCase):
             self._resource.resource_uri, public=False
         )
         _anon_resp = self._view(get_test_request(), pk=self._resource.pk)
-        self.assertEqual(_anon_resp.status_code, HTTPStatus.FORBIDDEN)
+        self.assertEqual(_anon_resp.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_unauthorized__public_resource(self):
         self._mock_osf.configure_resource_visibility(

--- a/addon_service/tests/test_hmac_api_auth.py
+++ b/addon_service/tests/test_hmac_api_auth.py
@@ -1,0 +1,209 @@
+from http import HTTPStatus
+from typing import Iterable
+from unittest import mock
+
+from django.conf import settings
+from django.core.exceptions import PermissionDenied
+from django.test import (
+    RequestFactory,
+    SimpleTestCase,
+)
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from addon_service.common import hmac as hmac_utils
+from addon_service.common import osf
+from addon_service.tests import _factories
+
+
+class TestOsfUtilsHmac(SimpleTestCase):
+    _fake_hmac_key = "so-secret-so-key"
+    _fake_api_url = "https://fake.example/api"
+    _fake_user_uri = "https://fake.example/user"
+    _fake_resource_uri = "https://fake.example/resource"
+
+    def setUp(self):
+        super().setUp()
+        self._mock_get_client = mock.AsyncMock()
+        self.enterContext(
+            mock.patch(
+                "addon_service.common.osf.get_singleton_client_session",
+                self._mock_get_client,
+            )
+        )
+        self.enterContext(self.settings(OSF_HMAC_KEY=self._fake_hmac_key))
+
+    def _fake_request(
+        self,
+        resource_permissions: Iterable[osf.OSFPermission] = (),
+        resource_uri=None,
+        user_uri=None,
+    ):
+        _additional_headers = {
+            osf._OSF_HMAC_USER_HEADER: user_uri or self._fake_user_uri,
+        }
+        if resource_permissions:
+            _additional_headers.update(
+                {
+                    osf._OSF_HMAC_RESOURCE_HEADER: resource_uri
+                    or self._fake_resource_uri,
+                    osf._OSF_HMAC_PERMISSIONS_HEADER: osf._OSF_HMAC_PERMISSIONS_DELIMITER.join(
+                        resource_permissions
+                    ),
+                }
+            )
+        return RequestFactory().get(
+            self._fake_api_url,
+            headers=hmac_utils.make_signed_headers(
+                request_url=self._fake_api_url,
+                request_method="GET",
+                hmac_key=self._fake_hmac_key,
+                additional_headers=_additional_headers,
+            ),
+        )
+
+    def test_get_osf_user_uri(self):
+        _actual_user_uri = osf.get_osf_user_uri(self._fake_request())
+        self.assertEqual(_actual_user_uri, self._fake_user_uri)
+        self.assertFalse(self._mock_get_client.called)
+
+    def test_get_osf_user_uri__wrong_key(self):
+        with self.settings(OSF_HMAC_KEY="nope"):
+            with self.assertRaises(PermissionDenied):
+                osf.get_osf_user_uri(self._fake_request())
+
+    def test_has_osf_permission_on_resource__read(self):
+        _fake_request = self._fake_request([osf.OSFPermission.READ])
+        self.assertTrue(
+            osf.has_osf_permission_on_resource(
+                _fake_request, self._fake_resource_uri, osf.OSFPermission.READ
+            )
+        )
+        self.assertFalse(
+            osf.has_osf_permission_on_resource(
+                _fake_request, self._fake_resource_uri, osf.OSFPermission.WRITE
+            )
+        )
+        self.assertFalse(
+            osf.has_osf_permission_on_resource(
+                _fake_request, self._fake_resource_uri, osf.OSFPermission.ADMIN
+            )
+        )
+        self.assertFalse(
+            osf.has_osf_permission_on_resource(
+                _fake_request, "http://another.example/resource", osf.OSFPermission.READ
+            )
+        )
+        self.assertFalse(
+            self._mock_get_client.called,
+            "should not try to send requests to osf when already hmac-verified",
+        )
+
+    def test_has_osf_permission_on_resource__admin(self):
+        _fake_request = self._fake_request(osf.OSFPermission)
+        self.assertTrue(
+            osf.has_osf_permission_on_resource(
+                _fake_request, self._fake_resource_uri, osf.OSFPermission.READ
+            )
+        )
+        self.assertTrue(
+            osf.has_osf_permission_on_resource(
+                _fake_request, self._fake_resource_uri, osf.OSFPermission.WRITE
+            )
+        )
+        self.assertTrue(
+            osf.has_osf_permission_on_resource(
+                _fake_request, self._fake_resource_uri, osf.OSFPermission.ADMIN
+            )
+        )
+        self.assertFalse(
+            osf.has_osf_permission_on_resource(
+                _fake_request, "http://another.example/resource", osf.OSFPermission.READ
+            )
+        )
+        self.assertFalse(self._mock_get_client.called)
+
+    def test_has_osf_permission_on_resource__none(self):
+        _fake_request = self._fake_request()
+        self.assertFalse(
+            osf.has_osf_permission_on_resource(
+                _fake_request, self._fake_resource_uri, osf.OSFPermission.READ
+            )
+        )
+        self.assertFalse(
+            osf.has_osf_permission_on_resource(
+                _fake_request, self._fake_resource_uri, osf.OSFPermission.WRITE
+            )
+        )
+        self.assertFalse(
+            osf.has_osf_permission_on_resource(
+                _fake_request, self._fake_resource_uri, osf.OSFPermission.ADMIN
+            )
+        )
+        self.assertFalse(
+            osf.has_osf_permission_on_resource(
+                _fake_request, "http://another.example/resource", osf.OSFPermission.READ
+            )
+        )
+        self.assertFalse(
+            self._mock_get_client.called,
+            "should not try to send requests to osf when already hmac-verified",
+        )
+
+    def test_has_osf_permission_on_resource__wrong_key(self):
+        with self.settings(OSF_HMAC_KEY="nope"):
+            self.assertFalse(
+                osf.has_osf_permission_on_resource(
+                    self._fake_request([osf.OSFPermission.READ]),
+                    self._fake_resource_uri,
+                    osf.OSFPermission.READ,
+                )
+            )
+
+
+class TestHmacApiAuth(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls._user = _factories.UserReferenceFactory()
+        cls._resource = _factories.ResourceReferenceFactory()
+        cls._service = _factories.ExternalStorageServiceFactory()
+        cls._account = _factories.AuthorizedStorageAccountFactory(
+            account_owner=cls._user,
+            external_storage_service=cls._service,
+        )
+        cls._addon = _factories.ConfiguredStorageAddonFactory(
+            base_account=cls._account,
+            authorized_resource=cls._resource,
+        )
+
+    def setUp(self):
+        super().setUp()
+        self._mock_get_client = mock.AsyncMock()
+        self.enterContext(
+            mock.patch(
+                "addon_service.common.osf.get_singleton_client_session",
+                self._mock_get_client,
+            )
+        )
+
+    def test_valid_hmac_auth(self):
+        _request_url = reverse(
+            "configured-storage-addons-detail",
+            kwargs={
+                "pk": self._addon.pk,
+            },
+        )
+        _response = self.client.get(
+            _request_url,
+            headers=hmac_utils.make_signed_headers(
+                request_url=_request_url,
+                request_method="GET",
+                hmac_key=settings.OSF_HMAC_KEY,
+                additional_headers={
+                    osf._OSF_HMAC_USER_HEADER: self._user.user_uri,
+                    osf._OSF_HMAC_RESOURCE_HEADER: self._resource.resource_uri,
+                    osf._OSF_HMAC_PERMISSIONS_HEADER: osf.OSFPermission.READ,
+                },
+            ),
+        )
+        self.assertTrue(HTTPStatus(_response.status_code).is_success)

--- a/app/env.py
+++ b/app/env.py
@@ -22,6 +22,7 @@ OSF_SENSITIVE_DATA_SALT = os.environ.get("OSF_SENSITIVE_DATA_SALT", "")
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 OSF_HMAC_KEY = os.environ.get("OSF_HMAC_KEY")
+OSF_HMAC_EXPIRATION_SECONDS = int(os.environ.get("OSF_HMAC_KEY", 110))
 
 OSF_BASE_URL = os.environ.get("OSF_BASE_URL", "https://osf.example")
 OSF_API_BASE_URL = os.environ.get("OSF_API_BASE_URL", "https://api.osf.example")

--- a/app/env.py
+++ b/app/env.py
@@ -22,7 +22,7 @@ OSF_SENSITIVE_DATA_SALT = os.environ.get("OSF_SENSITIVE_DATA_SALT", "")
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 OSF_HMAC_KEY = os.environ.get("OSF_HMAC_KEY")
-OSF_HMAC_EXPIRATION_SECONDS = int(os.environ.get("OSF_HMAC_KEY", 110))
+OSF_HMAC_EXPIRATION_SECONDS = int(os.environ.get("OSF_HMAC_EXPIRATION_SECONDS", 110))
 
 OSF_BASE_URL = os.environ.get("OSF_BASE_URL", "https://osf.example")
 OSF_API_BASE_URL = os.environ.get("OSF_API_BASE_URL", "https://api.osf.example")

--- a/app/settings.py
+++ b/app/settings.py
@@ -4,7 +4,8 @@ from app import env
 
 
 SECRET_KEY = env.SECRET_KEY
-DEFAULT_HMAC_KEY = env.OSF_HMAC_KEY or "lmaoooooo"
+OSF_HMAC_KEY = env.OSF_HMAC_KEY or "lmaoooooo"
+OSF_HMAC_EXPIRATION_SECONDS = env.OSF_HMAC_EXPIRATION_SECONDS
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -140,7 +141,9 @@ REST_FRAMEWORK = {
         "rest_framework_json_api.django_filters.DjangoFilterBackend",
         "rest_framework.filters.SearchFilter",
     ),
-    "DEFAULT_AUTHENTICATION_CLASSES": ("app.authentication.GVCombinedAuthentication",),
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "addon_service.authentication.GVCombinedAuthentication",
+    ),
     "SEARCH_PARAM": "filter[search]",
     "TEST_REQUEST_RENDERER_CLASSES": (
         "rest_framework_json_api.renderers.JSONRenderer",


### PR DESCRIPTION
- port some updates to `addon_service.common.hmac` from [osf.external.gravy_valet.auth_helpers](https://github.com/CenterForOpenScience/osf.io/blob/develop/osf/external/gravy_valet/auth_helpers.py)
- add specific exceptions for hmac situations
- when receiving an api request from osf, allow authenticating and authorizing with hmac-signed headers:
  - `X-Requesting-User-URI` for current user
  - `X-Requested-Resource-URI` for a single relevant resource
  - `X-Requested-Resource-Permissions` for the current user's osf permissions on the relevant resource
- rename setting `DEFAULT_HMAC_KEY` to `OSF_HMAC_KEY`; update hmac utils to require a key (easing futures with multiple hmac keys in play)

[ENG-5725]

[ENG-5725]: https://openscience.atlassian.net/browse/ENG-5725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ