### PR TITLE
Check whether test is running

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 from app import env
@@ -103,7 +104,7 @@ DATABASES = {
     },
 }
 
-if env.OSFDB_HOST:
+if env.OSFDB_HOST and not sys.argv[1:2] == ["test"]:
     DATABASES["osf"] = {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": env.OSFDB_NAME,


### PR DESCRIPTION
Currently, if we run tests locally, it is asking us to add 'osf' to the list of databases for tests. We have managed to avoid this by only appending the "osf" database configs when the `env.OSFDB_HOST` is set. This works for CI test runs but the same problem occurs locally when we try to run tests.

This PR tries to solve this problem by checking `sys.argv` to see if we are running tests. It works, but is this a hacky solution? Need some inputs/suggestions. @jwalz @aaxelb 

H/T @ly-mariia for discovering the problem.

