### PR TITLE
[ENG-6081] Unit tests failing in CI

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,3 +10,4 @@ jsonschema==4.21.1
 aiohttp==3.9.3
 pyjwe==1.0.0
 cryptography==42.0.7
+attrs==23.2.0


### PR DESCRIPTION
pinned attrs to 23.2.0, which raised deprecation warning and failed whole test suite