### PR TITLE
Fix `display_name` setter

### DIFF
--- a/addon_service/abstract/authorized_account/models.py
+++ b/addon_service/abstract/authorized_account/models.py
@@ -74,6 +74,7 @@ class AuthorizedAccount(AddonsServiceBaseModel):
 
     @display_name.setter
     def display_name(self, value: str):
+        value = value if value is not None else ""
         self._display_name = value
 
     @property

--- a/addon_service/abstract/configured_addon/models.py
+++ b/addon_service/abstract/configured_addon/models.py
@@ -49,7 +49,7 @@ class ConfiguredAddon(AddonsServiceBaseModel):
 
     @display_name.setter
     def display_name(self, value: str):
-        value = value if value is not None else ''
+        value = value if value is not None else ""
         self._display_name = value
 
     @property

--- a/addon_service/abstract/configured_addon/models.py
+++ b/addon_service/abstract/configured_addon/models.py
@@ -49,6 +49,7 @@ class ConfiguredAddon(AddonsServiceBaseModel):
 
     @display_name.setter
     def display_name(self, value: str):
+        value = value if value is not None else ''
         self._display_name = value
 
     @property


### PR DESCRIPTION
The setter for the `display_name` attribute on ConfiguredStorageAddon is trying to explicitly set a `None` value if passed one. This breaks the `null=False` database constraint.

Make the setter convert explicit `None` values to the empty string.