### PR TITLE
fix: don't break on no supported features

### DIFF
--- a/addon_service/external_storage_service/models.py
+++ b/addon_service/external_storage_service/models.py
@@ -59,7 +59,7 @@ class ExternalStorageService(ExternalService):
     @property
     def supported_features(self) -> list[SupportedFeatures]:
         """get the enum representation of int_supported_features"""
-        return SupportedFeatures(self.int_supported_features)
+        return SupportedFeatures(self.int_supported_features or 0)
 
     @supported_features.setter
     def supported_features(self, new_supported_features: SupportedFeatures):


### PR DESCRIPTION
allow `ExternalService.supported_features` to start out null; interpret null value as an empty set of flags