### PR TITLE
[ENG-6528] [ENG-6579] fixed permissions for configured addons

### DIFF
--- a/addon_service/common/permissions.py
+++ b/addon_service/common/permissions.py
@@ -60,7 +60,7 @@ class SessionUserMayConnectAddon(permissions.BasePermission):
             and osf.has_osf_permission_on_resource(
                 request,
                 obj.resource_uri,
-                osf.OSFPermission.ADMIN,
+                osf.OSFPermission.WRITE,
             )
         )
 


### PR DESCRIPTION
# Fixed Permisssion Model for Configured Addons
From now on:
- user may connect addon if they have at least READ+WRITE permission.
- user may edit addon if they have connected this addon or they have ADMIN access.