### PR TITLE
[ENG-6747] BE: Mendeley reconfigure error

### DIFF
--- a/addon_imps/tests/citations/test_mendeley.py
+++ b/addon_imps/tests/citations/test_mendeley.py
@@ -110,7 +110,7 @@ class TestMendeleyCitationImp(unittest.IsolatedAsyncioTestCase):
 
         expected_items = [
             ItemResult(
-                item_id="doc1",
+                item_id="document:doc1",
                 item_name="Doc Title 1",
                 item_type=ItemType.DOCUMENT,
                 item_path=[],
@@ -122,7 +122,7 @@ class TestMendeleyCitationImp(unittest.IsolatedAsyncioTestCase):
                 },
             ),
             ItemResult(
-                item_id="doc2",
+                item_id="document:doc2",
                 item_name="Doc Title 2",
                 item_type=ItemType.DOCUMENT,
                 item_path=[],
@@ -150,10 +150,14 @@ class TestMendeleyCitationImp(unittest.IsolatedAsyncioTestCase):
         expected_result = ItemSampleResult(
             items=[
                 ItemResult(
-                    item_id="1", item_name="Collection 1", item_type=ItemType.COLLECTION
+                    item_id="collection:1",
+                    item_name="Collection 1",
+                    item_type=ItemType.COLLECTION,
                 ),
                 ItemResult(
-                    item_id="2", item_name="Collection 2", item_type=ItemType.COLLECTION
+                    item_id="collection:2",
+                    item_name="Collection 2",
+                    item_type=ItemType.COLLECTION,
                 ),
             ],
             total_count=2,
@@ -205,7 +209,7 @@ class TestMendeleyCitationImp(unittest.IsolatedAsyncioTestCase):
         ) in cases:
             with self.subTest(item_filter):
                 result = await self.mendeley_imp.list_collection_items(
-                    "collection_id", filter_items=item_filter
+                    "collection:collection_id", filter_items=item_filter
                 )
                 for call in calls_to_be_made:
                     call.assert_awaited_once_with("collection_id")

--- a/addon_service/management/commands/migrate_authorized_account.py
+++ b/addon_service/management/commands/migrate_authorized_account.py
@@ -114,9 +114,9 @@ def get_root_folder_for_provider(node_settings, service_name):
         case "bitbucket":
             return f"repository:{node_settings.user}/{node_settings.repo}"
         case "zotero":
-            return f"{node_settings.library_id}/{node_settings.list_id}"
+            return f"collection:{node_settings.library_id}:{node_settings.list_id}"
         case "mendeley":
-            return node_settings.list_id
+            return f"collection:{node_settings.list_id}"
         case "boa":
             return None
 

--- a/addon_toolkit/interfaces/citation.py
+++ b/addon_toolkit/interfaces/citation.py
@@ -77,6 +77,10 @@ class CitationServiceInterface(BaseAddonInterface):
     ) -> ItemSampleResult:
         """Lists directories (or collections) and sources (books) inside root"""
 
+    @immediate_operation(capability=AddonCapabilities.ACCESS)
+    def get_item_info(self, item_id: str) -> ItemResult:
+        """Lists directories (or collections) and sources (books) inside root"""
+
 
 @dataclasses.dataclass(frozen=True)
 class CitationAddonImp(AddonImp):


### PR DESCRIPTION
- added get_item_info API call
- changed item_id for mendeley and Zotero to include ItemType **BREAKING**: will need to reconfigure respective addons
- edited account migrations to reflect on changes in item_id