### PR TITLE
[ENG-6773] BE: Figshare: Configuration page displays all Figshare items instead of only projects.

### DIFF
--- a/addon_imps/storage/figshare.py
+++ b/addon_imps/storage/figshare.py
@@ -18,7 +18,7 @@ from addon_toolkit.interfaces.storage import (
 FILE_REGEX = re.compile(r"^article/(?P<article_id>\d*)/files/(?P<file_id>\d*)$")
 ARTICLE_REGEX = re.compile(r"^article/(?P<article_id>\d*)$")
 PROJECT_REGEX = re.compile(r"^project/(?P<project_id>\d*)$")
-
+FOLDER_ITEM_TYPES = {3, 4}
 PAGE_SIZE = 20
 
 
@@ -101,7 +101,9 @@ class FigshareStorageImp(storage.StorageAddonHttpRequestorImp):
         ) as response:
             await self._check_response(response)
             return [
-                Article.from_json(project) for project in await response.json_content()
+                Article.from_json(raw_article)
+                for raw_article in await response.json_content()
+                if raw_article["defined_type"] in FOLDER_ITEM_TYPES
             ]
 
     async def _fetch_project_articles(
@@ -116,7 +118,11 @@ class FigshareStorageImp(storage.StorageAddonHttpRequestorImp):
         ) as response:
             await self._check_response(response)
             json = await response.json_content()
-            return [Article.from_json(project) for project in json]
+            return [
+                Article.from_json(raw_article)
+                for raw_article in json
+                if raw_article["defined_type"] in FOLDER_ITEM_TYPES
+            ]
 
     async def _fetch_article_files(
         self, article_id: str, page_cursor: int

--- a/addon_imps/tests/storage/test_figshare.py
+++ b/addon_imps/tests/storage/test_figshare.py
@@ -233,7 +233,10 @@ class TestFigshareStorageImp(IsolatedAsyncioTestCase):
                 self.imp._fetch_project_articles,
                 "lalala",
                 "account/projects/lalala/articles",
-                [{"id": 123, "title": "sdaas"}],
+                [
+                    {"id": 123, "title": "sdaas", "defined_type": 4},
+                    {"id": 6436, "title": "sdaas", "defined_type": 3123123},
+                ],
                 [Article(id=123, title="sdaas")],
             ],
             [
@@ -247,7 +250,10 @@ class TestFigshareStorageImp(IsolatedAsyncioTestCase):
                 self.imp._fetch_articles,
                 None,
                 "account/articles",
-                [{"id": 123, "title": "sdaas"}],
+                [
+                    {"id": 123, "title": "sdaas", "defined_type": 4},
+                    {"id": 567, "title": "sdaas", "defined_type": 1234},
+                ],
                 [Article(id=123, title="sdaas")],
             ],
             [


### PR DESCRIPTION
Limited GV to return only filesets and datasets during figshare configuration