### PR TITLE
[ENG-6323] BE/Platform: Files Page: Providers list are no longer listed alphabetical order

### DIFF
--- a/addon_service/resource_reference/models.py
+++ b/addon_service/resource_reference/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models.functions import Lower
 
 from addon_service.common.base_model import AddonsServiceBaseModel
 from addon_service.configured_addon.citation.models import ConfiguredCitationAddon
@@ -12,7 +13,7 @@ class ResourceReference(AddonsServiceBaseModel):
     @property
     def configured_storage_addons(self):
         return ConfiguredStorageAddon.objects.filter(authorized_resource=self).order_by(
-            "_display_name"
+            Lower("_display_name")
         )
 
     @property

--- a/addon_service/resource_reference/models.py
+++ b/addon_service/resource_reference/models.py
@@ -11,7 +11,9 @@ class ResourceReference(AddonsServiceBaseModel):
 
     @property
     def configured_storage_addons(self):
-        return ConfiguredStorageAddon.objects.filter(authorized_resource=self)
+        return ConfiguredStorageAddon.objects.filter(authorized_resource=self).order_by(
+            "_display_name"
+        )
 
     @property
     def configured_citation_addons(self):


### PR DESCRIPTION
added alphabetical ordering for configured_storage_addons queried from resource_reference

**Important**: Until recently we could configure addons without specifying `display_name`, and it would be fetched from respective account, but now display name is required field (on frontend).  Therefore, this fix may not resolve issue completely until all storage addons are reconfigured. 