### PR TITLE
[ENG-6831] Fixed external_service_name to match wb_key

### DIFF
--- a/addon_service/common/known_imps.py
+++ b/addon_service/common/known_imps.py
@@ -69,18 +69,18 @@ def get_imp_number(imp: type[AddonImp]) -> int:
 class KnownAddonImps(enum.Enum):
     """Static mapping from API-facing name for an AddonImp to the Imp itself"""
 
-    BOX_DOT_COM = box_dot_com.BoxDotComStorageImp
+    BOX = box_dot_com.BoxDotComStorageImp
     S3 = s3.S3StorageImp
     ONEDRIVE = onedrive.OneDriveStorageImp
-    ZOTERO_ORG = zotero_org.ZoteroOrgCitationImp
-    GOOGLE_DRIVE = google_drive.GoogleDriveStorageImp
+    ZOTERO = zotero_org.ZoteroOrgCitationImp
+    GOOGLEDRIVE = google_drive.GoogleDriveStorageImp
     FIGSHARE = figshare.FigshareStorageImp
     MENDELEY = mendeley.MendeleyCitationImp
     BITBUCKET = bitbucket.BitbucketStorageImp
     DATAVERSE = dataverse.DataverseStorageImp
     OWNCLOUD = owncloud.OwnCloudStorageImp
 
-    GIT_HUB = github.GitHubStorageImp
+    GITHUB = github.GitHubStorageImp
     GITLAB = gitlab.GitlabStorageImp
     DROPBOX = dropbox.DropboxStorageImp
 
@@ -95,11 +95,11 @@ class KnownAddonImps(enum.Enum):
 class AddonImpNumbers(enum.Enum):
     """Static mapping from each AddonImp name to a unique integer (for database use)"""
 
-    BOX_DOT_COM = 1001
-    ZOTERO_ORG = 1002
+    BOX = 1001
+    ZOTERO = 1002
     S3 = 1003
     MENDELEY = 1004
-    GOOGLE_DRIVE = 1005
+    GOOGLEDRIVE = 1005
     DROPBOX = 1006
     FIGSHARE = 1007
     ONEDRIVE = 1008
@@ -108,7 +108,7 @@ class AddonImpNumbers(enum.Enum):
     GITLAB = 1011
     BITBUCKET = 1012
 
-    GIT_HUB = 1013
+    GITHUB = 1013
 
     BOA = 1020
 

--- a/addon_service/configured_addon/citation/models.py
+++ b/addon_service/configured_addon/citation/models.py
@@ -1,6 +1,5 @@
 from django.db import models
 
-from addon_service.common.known_imps import AddonImpNumbers
 from addon_service.configured_addon.models import ConfiguredAddon
 from addon_toolkit.interfaces.citation import CitationConfig
 
@@ -20,8 +19,3 @@ class ConfiguredCitationAddon(ConfiguredAddon):
     @property
     def config(self) -> CitationConfig:
         return self.base_account.authorizedcitationaccount.config
-
-    @property
-    def external_service_name(self):
-        number = self.base_account.external_service.int_addon_imp
-        return AddonImpNumbers(number).name.lower()

--- a/addon_service/configured_addon/computing/serializers.py
+++ b/addon_service/configured_addon/computing/serializers.py
@@ -71,4 +71,5 @@ class ConfiguredComputingAddonSerializer(ConfiguredAddonSerializer):
             "external_service_name",
             "external_computing_service",
             "current_user_is_owner",
+            "external_service_name",
         ]

--- a/addon_service/configured_addon/models.py
+++ b/addon_service/configured_addon/models.py
@@ -5,6 +5,7 @@ from django.db import models
 
 from addon_service.addon_operation.models import AddonOperationModel
 from addon_service.common.base_model import AddonsServiceBaseModel
+from addon_service.common.known_imps import AddonImpNumbers
 from addon_service.common.validators import validate_addon_capability
 from addon_toolkit import (
     AddonCapabilities,
@@ -107,6 +108,11 @@ class ConfiguredAddon(AddonsServiceBaseModel):
     @property
     def imp_cls(self) -> type[AddonImp]:
         return self.base_account.imp_cls
+
+    @property
+    def external_service_name(self):
+        number = self.base_account.external_service.int_addon_imp
+        return AddonImpNumbers(number).name.lower()
 
     def clean_fields(self, *args, **kwargs):
         super().clean_fields(*args, **kwargs)

--- a/addon_service/configured_addon/serializers.py
+++ b/addon_service/configured_addon/serializers.py
@@ -72,4 +72,5 @@ class ConfiguredAddonSerializer(serializers.HyperlinkedModelSerializer):
             "connected_operations",
             "connected_operation_names",
             "current_user_is_owner",
+            "external_service_name",
         ]

--- a/addon_service/configured_addon/storage/serializers.py
+++ b/addon_service/configured_addon/storage/serializers.py
@@ -72,4 +72,5 @@ class ConfiguredStorageAddonSerializer(ConfiguredAddonSerializer):
             "connected_operation_names",
             "external_storage_service",
             "current_user_is_owner",
+            "external_service_name",
         ]


### PR DESCRIPTION
This allows us to seemlessly migrate from wb_key to external_service_name, moreover, this helps with removal of `_LegacyConfigsForWBKey` from osf.io without performance drawbacks