### PR TITLE
Only refresh token if the token have expired when returning wb creds

### DIFF
--- a/addon_service/authorized_account/models.py
+++ b/addon_service/authorized_account/models.py
@@ -7,6 +7,7 @@ from django.db import (
     models,
     transaction,
 )
+from django.utils import timezone
 
 from addon_service.addon_imp.instantiation import get_addon_instance
 from addon_service.addon_operation.models import AddonOperationModel
@@ -315,7 +316,7 @@ class AuthorizedAccount(AddonsServiceBaseModel):
     ###
     # async functions for use in oauth2 callback flows
 
-    async def refresh_oauth2_access_token(self) -> None:
+    async def refresh_oauth2_access_token(self, force=False) -> None:
         (
             _oauth_client_config,
             _oauth_token_metadata,
@@ -325,15 +326,16 @@ class AuthorizedAccount(AddonsServiceBaseModel):
             or await sync_to_async(lambda: _oauth_token_metadata.access_token_only)()
         ):
             return
-        _fresh_token_result = await oauth2_utils.get_refreshed_access_token(
-            token_endpoint_url=_oauth_client_config.token_endpoint_url,
-            refresh_token=_oauth_token_metadata.refresh_token,
-            auth_callback_url=_oauth_client_config.auth_callback_url,
-            client_id=_oauth_client_config.client_id,
-            client_secret=_oauth_client_config.client_secret,
-        )
-        await _oauth_token_metadata.update_with_fresh_token(_fresh_token_result)
-        await self.arefresh_from_db()
+        if force or _oauth_token_metadata.access_token_expiration < timezone.now():
+            _fresh_token_result = await oauth2_utils.get_refreshed_access_token(
+                token_endpoint_url=_oauth_client_config.token_endpoint_url,
+                refresh_token=_oauth_token_metadata.refresh_token,
+                auth_callback_url=_oauth_client_config.auth_callback_url,
+                client_id=_oauth_client_config.client_id,
+                client_secret=_oauth_client_config.client_secret,
+            )
+            await _oauth_token_metadata.update_with_fresh_token(_fresh_token_result)
+            await self.arefresh_from_db()
 
     refresh_oauth_access_token__blocking = async_to_sync(refresh_oauth2_access_token)
 

--- a/addon_service/common/network.py
+++ b/addon_service/common/network.py
@@ -83,7 +83,9 @@ class GravyvaletHttpRequestor(HttpRequestor):
             async with self._try_send(request) as _response:
                 yield _response
         except exceptions.ExpiredAccessToken:
-            await _PrivateNetworkInfo.get(self).account.refresh_oauth2_access_token()
+            await _PrivateNetworkInfo.get(self).account.refresh_oauth2_access_token(
+                force=True
+            )
             # if this one fails, don't try refreshing again
             async with self._try_send(request) as _response:
                 yield _response

--- a/addon_service/configured_addon/storage/views.py
+++ b/addon_service/configured_addon/storage/views.py
@@ -29,13 +29,11 @@ class ConfiguredStorageAddonViewSet(ConfiguredAddonViewSet):
     )
     def get_wb_credentials(self, request, pk=None):
         addon: ConfiguredStorageAddon = self.get_object()
-        token_expiration = (
-            addon.base_account.oauth2_token_metadata.access_token_expiration
-        )
         if (
             addon.external_service.credentials_format is CredentialsFormats.OAUTH2
-            and token_expiration
-            and token_expiration < timezone.now()
+            and addon.base_account.oauth2_token_metadata.access_token_expiration
+            and addon.base_account.oauth2_token_metadata.access_token_expiration
+            < timezone.now()
         ):
             addon.base_account.refresh_oauth_access_token__blocking()
         self.resource_name = "waterbutler-credentials"  # for the jsonapi resource type

--- a/addon_service/configured_addon/storage/views.py
+++ b/addon_service/configured_addon/storage/views.py
@@ -1,5 +1,6 @@
 from http import HTTPMethod
 
+from django.utils import timezone
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
@@ -28,7 +29,14 @@ class ConfiguredStorageAddonViewSet(ConfiguredAddonViewSet):
     )
     def get_wb_credentials(self, request, pk=None):
         addon: ConfiguredStorageAddon = self.get_object()
-        if addon.external_service.credentials_format is CredentialsFormats.OAUTH2:
+        token_expiration = (
+            addon.base_account.oauth2_token_metadata.access_token_expiration
+        )
+        if (
+            addon.external_service.credentials_format is CredentialsFormats.OAUTH2
+            and token_expiration
+            and token_expiration < timezone.now()
+        ):
             addon.base_account.refresh_oauth_access_token__blocking()
         self.resource_name = "waterbutler-credentials"  # for the jsonapi resource type
         return Response(WaterButlerConfigSerializer(addon).data)

--- a/addon_service/configured_addon/storage/views.py
+++ b/addon_service/configured_addon/storage/views.py
@@ -1,6 +1,5 @@
 from http import HTTPMethod
 
-from django.utils import timezone
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
@@ -29,12 +28,7 @@ class ConfiguredStorageAddonViewSet(ConfiguredAddonViewSet):
     )
     def get_wb_credentials(self, request, pk=None):
         addon: ConfiguredStorageAddon = self.get_object()
-        if (
-            addon.external_service.credentials_format is CredentialsFormats.OAUTH2
-            and addon.base_account.oauth2_token_metadata.access_token_expiration
-            and addon.base_account.oauth2_token_metadata.access_token_expiration
-            < timezone.now()
-        ):
+        if addon.external_service.credentials_format is CredentialsFormats.OAUTH2:
             addon.base_account.refresh_oauth_access_token__blocking()
         self.resource_name = "waterbutler-credentials"  # for the jsonapi resource type
         return Response(WaterButlerConfigSerializer(addon).data)

--- a/addon_service/management/commands/refresh_addon_tokens.py
+++ b/addon_service/management/commands/refresh_addon_tokens.py
@@ -44,7 +44,7 @@ def refresh_addon_tokens_for_external_service(
 
             allowance -= 1
             last_call = time.time()
-            account.refresh_oauth_access_token__blocking()
+            account.refresh_oauth_access_token__blocking(force=True)
 
 
 @celery.shared_task

--- a/addon_service/management/commands/refresh_addon_tokens.py
+++ b/addon_service/management/commands/refresh_addon_tokens.py
@@ -68,4 +68,11 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         fake = options["fake"]
-        refresh_addon_tokens(addons=["box", "googledrive", "mendeley"], fake=fake)
+        refresh_addon_tokens(
+            addons={
+                "box": 60,
+                "googledrive": 14,
+                "mendeley": 14,
+            },
+            fake=fake,
+        )


### PR DESCRIPTION
We suspect that constant calls to external services to refresh tokens is behind the reason why performance is slow on staging and test. So we should only refresh tokens when we need to.