### PR TITLE
Refresh tokens fix

### DIFF
--- a/addon_service/authorized_account/models.py
+++ b/addon_service/authorized_account/models.py
@@ -7,6 +7,7 @@ from django.db import (
     models,
     transaction,
 )
+from django.utils import timezone
 
 from addon_service.addon_imp.instantiation import get_addon_instance
 from addon_service.addon_operation.models import AddonOperationModel
@@ -315,7 +316,7 @@ class AuthorizedAccount(AddonsServiceBaseModel):
     ###
     # async functions for use in oauth2 callback flows
 
-    async def refresh_oauth2_access_token(self) -> None:
+    async def refresh_oauth2_access_token(self, force=False) -> None:
         (
             _oauth_client_config,
             _oauth_token_metadata,
@@ -325,15 +326,16 @@ class AuthorizedAccount(AddonsServiceBaseModel):
             or await sync_to_async(lambda: _oauth_token_metadata.access_token_only)()
         ):
             return
-        _fresh_token_result = await oauth2_utils.get_refreshed_access_token(
-            token_endpoint_url=_oauth_client_config.token_endpoint_url,
-            refresh_token=_oauth_token_metadata.refresh_token,
-            auth_callback_url=_oauth_client_config.auth_callback_url,
-            client_id=_oauth_client_config.client_id,
-            client_secret=_oauth_client_config.client_secret,
-        )
-        await _oauth_token_metadata.update_with_fresh_token(_fresh_token_result)
-        await self.arefresh_from_db()
+        if force or _oauth_token_metadata.access_token_expiration < timezone.now():
+            _fresh_token_result = await oauth2_utils.get_refreshed_access_token(
+                token_endpoint_url=_oauth_client_config.token_endpoint_url,
+                refresh_token=_oauth_token_metadata.refresh_token,
+                auth_callback_url=_oauth_client_config.auth_callback_url,
+                client_id=_oauth_client_config.client_id,
+                client_secret=_oauth_client_config.client_secret,
+            )
+            await _oauth_token_metadata.update_with_fresh_token(_fresh_token_result)
+            await self.arefresh_from_db()
 
     refresh_oauth_access_token__blocking = async_to_sync(refresh_oauth2_access_token)
 

--- a/addon_service/authorized_account/models.py
+++ b/addon_service/authorized_account/models.py
@@ -326,7 +326,11 @@ class AuthorizedAccount(AddonsServiceBaseModel):
             or await sync_to_async(lambda: _oauth_token_metadata.access_token_only)()
         ):
             return
-        if force or _oauth_token_metadata.access_token_expiration < timezone.now():
+        if (
+            force
+            or (not _oauth_token_metadata.access_token_expiration)
+            or _oauth_token_metadata.access_token_expiration < timezone.now()
+        ):
             _fresh_token_result = await oauth2_utils.get_refreshed_access_token(
                 token_endpoint_url=_oauth_client_config.token_endpoint_url,
                 refresh_token=_oauth_token_metadata.refresh_token,

--- a/addon_service/common/network.py
+++ b/addon_service/common/network.py
@@ -83,7 +83,9 @@ class GravyvaletHttpRequestor(HttpRequestor):
             async with self._try_send(request) as _response:
                 yield _response
         except exceptions.ExpiredAccessToken:
-            await _PrivateNetworkInfo.get(self).account.refresh_oauth2_access_token()
+            await _PrivateNetworkInfo.get(self).account.refresh_oauth2_access_token(
+                force=True
+            )
             # if this one fails, don't try refreshing again
             async with self._try_send(request) as _response:
                 yield _response

--- a/addon_service/management/commands/refresh_addon_tokens.py
+++ b/addon_service/management/commands/refresh_addon_tokens.py
@@ -44,7 +44,7 @@ def refresh_addon_tokens_for_external_service(
 
             allowance -= 1
             last_call = time.time()
-            account.refresh_oauth_access_token__blocking()
+            account.refresh_oauth_access_token__blocking(force=True)
 
 
 @celery.shared_task
@@ -68,4 +68,11 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         fake = options["fake"]
-        refresh_addon_tokens(addons=["box", "googledrive", "mendeley"], fake=fake)
+        refresh_addon_tokens(
+            addons={
+                "box": 60,
+                "googledrive": 14,
+                "mendeley": 14,
+            },
+            fake=fake,
+        )


### PR DESCRIPTION
Redux of the previously reverted performance improvement. This time we refresh token when there is no `access_token_expiration`