### PR TITLE
[ENG-8454] Fixed aborting fetching a directory when ValidationError is raised

### DIFF
--- a/addon_imps/storage/gitlab.py
+++ b/addon_imps/storage/gitlab.py
@@ -139,8 +139,15 @@ class GitlabStorageImp(storage.StorageAddonHttpRequestorImp):
             await self.check_preconditions(response)
             content = await response.json_content()
             ref = content.get("default_branch")
-        if file_item := await self._get_file(parsed_id, ref):
+
+        try:
+            file_item = await self._get_file(parsed_id, ref)
+        except ValidationError:
+            file_item = None
+
+        if file_item:
             return file_item
+
         # try to list files under folder, if it succeeds, proceed to return folder, else propagate the error
         await self.list_child_items(parsed_id.raw_id)
         return ItemResult(


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-8454

## Purpose

User cannot configure already connected gitlab addon because of 404 error from Gitlab that says `File not found` when user attempts to configure root directory for the existing gitlab addon

If ValidationError is raised on 142 line, the request is aborted instead of trying to fetch subdirectories

https://github.com/CenterForOpenScience/gravyvalet/blob/e16c526dc1cf16ba4ac2285eaadb15de72cd7ff3/addon_imps/storage/gitlab.py#L135-L145

## Changes

Handle ValidationError and if user doesn't try to fetch a file, ValidationError will be raised and we'll try to fetch subdirectories instead of aborting the request